### PR TITLE
Resolve placeholder round-trip follow-ups; groundwork for Python-in-Nix

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -63,7 +63,11 @@ pre-existing error rather than hiding it.
 _Avoid_: escaped variable
 
 **Interpreted placeholder**:
-A parent interpolation the parent evaluates — in Nix, `${pkgs.hello}`. Ninjection
-rewrites it to an injected-language-safe identifier (see Rename mapping) for
-editing and restores it on write-back. Substituting the parent's *real* evaluated
-value (rather than a default) is a future enhancement.
+A parent interpolation the parent evaluates — in Nix, `${pkgs.hello}`. Whether
+ninjection rewrites it for editing depends on the *injected* language: where the
+injected language reads `${…}` as live syntax (shell expansion), it is rewritten
+to an injected-language-safe identifier (see Rename mapping) and restored on
+write-back; where `${…}` is inert in the injected language (e.g. inside a Python
+string literal it is ordinary text), the interpolation is left verbatim and
+round-trips unchanged. Substituting the parent's *real* evaluated value (rather
+than a default) is a future enhancement.

--- a/TODO.md
+++ b/TODO.md
@@ -9,10 +9,34 @@ Implemented (branch `feat/placeholder-roundtrip`):
 Follow-up:
 - [ ] checkhealth: report the injected-language Treesitter grammar requirement
       for the placeholder round-trip (degrades gracefully today)
-- [ ] Resolve the `cfg.debug`-guarded string restorer in `replace()` — currently
-      inert and accidentally load-bearing (see docs/adr/0001 notes / memory)
+- [x] Resolve the `cfg.debug`-guarded string restorer in `replace()` — NOT inert:
+      it re-adds the outer `''…'';` block delimiters and is load-bearing for every
+      round-trip (the write-back range covers the whole injected node, delimiters
+      included). The guard was a latent corruption bug — `debug=false` silently
+      dropped the delimiters. Guard removed; `debug` now gates only diagnostics.
+- [x] Delimiter model decided (ADR-0005 area): committed to the string
+      modifier/restorer for the outer `''…'';`. Deleted the dead, never-wired
+      `inj_lang_tweaks`/`parse_range_offset`/`buffer_cursor_offset` config + types
+      (an abandoned range-exclusion design that had misled analysis). The inner
+      escape/interp round-trip stays separate and Treesitter-based.
+      (doc/ninjection.txt is generated; gendocs CI will drop the stale NJLangTweak
+      entries on next run.)
+- [ ] Bug: closing `'';` returns at the wrong indent on write-back for some
+      indentation patterns (e.g. Python l_indent=6 -> 2 spaces instead of 4). In
+      the restorer's `tab_indent = l_indent - tabstop` math. Pre-existing, not
+      Python-specific.
 - [ ] Real value interpolation for interpreted placeholders (default `""`/`nil` today)
+      — deferred + documented in ADR-0005: needs extmark-based position tracking
+      (Treesitter can't re-find a site whose text became the evaluated value, esp.
+      inside a string). An interpolation is a tracked site + rendering policy.
 - [ ] Generalise beyond a Nix host / bash+sh injected languages
+      - In progress: Python injected in Nix (parent stays Nix). Interpolation
+        handling must become injected-keyed — shell rewrites `${x}`, Python leaves
+        string-position interps verbatim (else the store path is corrupted).
+      - Edge case (deferred): a Nix writer used as a bare top-level expression
+        (`pkgs.writers.writePython3Bin "n" {...} ''...''`) isn't `;`-terminated
+        like a `name = ... ;` binding; the round-trip range/restore logic assumes
+        the assignment form. Workaround: wrap in `let x = <writer> ...; in { }`.
 - [ ] Foldable ninjection block: wrap declarations in `{ ... }` with indentation
       so Neovim can fold/collapse a large header, e.g.
       `# >>> ninjection:nix` / `{` / `  var1=""` / `  ...` / `}` / `# <<< ninjection`

--- a/doc/ninjection.txt
+++ b/doc/ninjection.txt
@@ -126,22 +126,6 @@ NOTE: width/height col/row default values are dynamically set to:
 `      )
 `    "
 `  },
-`  inj_lang_tweaks = {
-`    nix = {
-`      buffer_cursor_offset = {
-`        e_col = 0,
-`        e_row = -1,
-`        s_col = 0,
-`        s_row = 1
-`      },
-`      parse_range_offset = {
-`        e_col = 120,
-`        e_row = -1,
-`        s_col = -120,
-`        s_row = 1
-`      }
-`    }
-`  },
 `  inj_text_modifiers = {
 `    lua = <function 1>,
 `    nix = <function 2>
@@ -250,10 +234,6 @@ per-language functions to modify text returned by the lang query
 {inj_text_restorers} `(optional)` `(table<string, fun(text: string, metadata: table<string, boolean>, indents?: NJIndents): string[]>)` - Contains
 per-language functions to restore modified text
 
-{inj_lang_tweaks} `(optional)` `(table<string, NJLangTweak>)` - Contains
-language functions to workaround limitations in Treesitter queries and post-process
-injected content selections.
-
 {lsp_map} `(optional)` `(table<string, string>)` - Maps the injected language filetype
 comment to an LSP configuration name for that filetype.
                                                                        *NJRange*
@@ -279,13 +259,6 @@ Store a language string and its associated node.
 
 {inj_lang} `(string)` Language tag extracted from inj_lang capture
 {node} `(TSNode)` Node associated with the injected code
-                                                                   *NJLangTweak*
-Class ~
-{NJLangTweak}
-Language specific adjustments for tweaking parsing and buffers.
-
-{parse_range_offset} `(NJRange)`
-{buffer_cursor_offset} `(NJRange)`
                                                                    *NJNodeTable*
 Class ~
 {NJNodeTable}

--- a/doc/tags
+++ b/doc/tags
@@ -2,7 +2,6 @@ EditorStyle	ninjection.txt	/*EditorStyle*
 NJCapturePair	ninjection.txt	/*NJCapturePair*
 NJDelimiterPair	ninjection.txt	/*NJDelimiterPair*
 NJIndents	ninjection.txt	/*NJIndents*
-NJLangTweak	ninjection.txt	/*NJLangTweak*
 NJNodeTable	ninjection.txt	/*NJNodeTable*
 NJRange	ninjection.txt	/*NJRange*
 Ninjection.CmdOpts	ninjection.txt	/*Ninjection.CmdOpts*

--- a/docs/adr/0005-interpolation-handling-is-injected-language-keyed.md
+++ b/docs/adr/0005-interpolation-handling-is-injected-language-keyed.md
@@ -1,0 +1,63 @@
+# Interpolation handling is injected-language-keyed
+
+Rewriting a parent interpolation into an editable placeholder is governed by the
+**injected** language, not only the parent. The bash round-trip rewrites a Nix
+`${expr}` to a safe identifier and restores it by finding an `expansion` node in
+the child grammar (see ADR-0001/0002). That works only because of a *coincidence*:
+Nix interpolation syntax `${x}` is identical to bash expansion syntax `${x}`, so
+bash's Treesitter parses the site as an `expansion` even inside a string, and
+reverse() can re-find it.
+
+This does not generalise. Verified against Python's grammar:
+
+- A Nix interpolation **inside a Python string** (`"${pkgs.gnugrep}/bin/grep"`,
+  the canonical `writePython3Bin` shape) is inert `string_content` — valid, no
+  diagnostic, and Treesitter exposes no node distinguishing it from ordinary text.
+- A Nix interpolation **in code position** (`x = ${cfg.y}`) is a syntax error.
+
+So the bash rewrite is actively harmful for Python: `forward()` rewriting the
+string-position interpolation to `${pkgs_0x2E_gnugrep}` permanently corrupts the
+store path, because `reverse()` (no `expansion` node in the Python grammar) cannot
+undo it.
+
+## Decision
+
+Interpolation handling is keyed on the injected language. Shell-family injected
+languages — whose grammar reads `${…}` as a live expansion — get the
+rewrite-and-restore. Every other injected language passes interpolations through
+**verbatim**: the interpolation is left in parent form and round-trips unchanged.
+De-escaping a Nix literal escape (`''${x}`) in a non-shell injected language is
+deferred on the same grounds (restore cannot re-find it). `forward()` therefore
+takes the injected language (today it receives only the parent language) to select
+the policy.
+
+Python consequently rides the existing path shared with Lua — the outer-`''`
+modifier/restorer plus dedent — and needs no shebang or ninjection block for the
+canonical case, because nothing is declared.
+
+Frame: an interpolation is a **tracked site with a rendering policy** — rewrite to
+a safe identifier (shell), leave verbatim (non-shell), or, in future, substitute
+the parent's real evaluated value.
+
+## Consequences
+
+- **Real-value resolution (deferred) is not foreclosed, but this is where it
+  re-enters.** Substituting the parent's evaluated value replaces the child text
+  entirely (a store path, not `${…}`), so restore can no longer locate the site
+  via Treesitter — least of all inside a string, where TS never saw it. Real-value
+  resolution will require position-stable tracking (extmarks placed at each
+  interpolation site) rather than the current TS-based reverse. Passthrough today
+  makes restore a trivial no-op; that is precisely the assumption real-value must
+  revisit. Accepted: we document the path rather than build extmark tracking now.
+- The placeholder token shape (`${name}` for shell vs. a bare identifier for a
+  declared placeholder) and the placeholder node type (`expansion` vs.
+  `identifier`) are properties of the injected language, not constants. They were
+  hardcoded in `placeholder.lua`; generalising moves them onto the injected-keyed
+  header descriptor.
+- This sharpens ADR-0003. ADR-0003 says the child validates only its own language;
+  this ADR adds that the round-trip *transform* is itself injected-keyed — a
+  language ninjection does not recognise as `${}`-interpreting gets a verbatim
+  pass, never a corrupting rewrite.
+- The code-vs-string classification needed to handle code-position interpolations
+  in non-shell languages (a future enhancement) is Treesitter-decidable — is the
+  site inside a `string_content` node? — so it stays within ADR-0002.

--- a/flake.nix
+++ b/flake.nix
@@ -98,6 +98,7 @@
         projectPkgs = with pkgs; [
           lua-language-server
           nixd
+          ruff
           stylua
           luajitPackages.luacheck
           luajitPackages.busted

--- a/lua/ninjection/config.lua
+++ b/lua/ninjection/config.lua
@@ -219,17 +219,6 @@ local default_config = {
 		end,
 	},
 
-	---@type table<string, NJLangTweak>
-	inj_lang_tweaks = {
-		---@type NJLangTweak
-		nix = {
-			---@type NJRange
-			parse_range_offset = { s_row = 1, e_row = -1, s_col = -120, e_col = 120 },
-			---@type NJRange
-			buffer_cursor_offset = { s_row = 1, e_row = -1, s_col = 0, e_col = 0 },
-		},
-	},
-
 	---@type table<string, string>
 	lsp_map = {
 		bash = "bashls",

--- a/lua/ninjection/init.lua
+++ b/lua/ninjection/init.lua
@@ -370,32 +370,41 @@ function ninjection.replace()
 		rep_lines = restored_lines
 	end
 
-	if cfg.debug then
-		if not cfg.inj_text_restorers then
+	-- Restore the parent's outer string delimiters (e.g. Nix ''...'') that the
+	-- inj_text_modifier stripped for editing. The write-back range covers the
+	-- whole injected node including those delimiters, so this restore is
+	-- load-bearing for every round-trip; it must run regardless of `cfg.debug`,
+	-- which gates only verbose diagnostics. See docs/adr/0001.
+	if not cfg.inj_text_restorers then
+		if cfg.debug then
 			vim.notify("cfg.inj_text_restorers is nil", vim.log.levels.WARN)
-		elseif not cfg.inj_text_restorers[nj_child.p_ft] then
+		end
+	elseif not cfg.inj_text_restorers[nj_child.p_ft] then
+		if cfg.debug then
 			vim.notify("No restorer defined for filetype: " .. tostring(nj_child.p_ft), vim.log.levels.WARN)
-		elseif not nj_child.p_text_meta then
+		end
+	elseif not nj_child.p_text_meta then
+		if cfg.debug then
 			vim.notify("text_meta is nil for current injection", vim.log.levels.WARN)
-		else
+		end
+	else
+		---@type string
+		local rep_text = table.concat(rep_lines, "\n")
+		---@type boolean, string[]?
+		local restored_ok, restored_text =
+			pcall(cfg.inj_text_restorers[nj_child.p_ft], rep_text, nj_child.p_text_meta, nj_child.p_indents)
+		if not restored_ok or not restored_text or type(restored_text) ~= "table" then
 			---@type string
-			local rep_text = table.concat(rep_lines, "\n")
-			---@type boolean, string[]?
-			local restored_ok, restored_text =
-				pcall(cfg.inj_text_restorers[nj_child.p_ft], rep_text, nj_child.p_text_meta, nj_child.p_indents)
-			if not restored_ok or not restored_text or type(restored_text) ~= "table" then
-				---@type string
-				local err = "ninjection.replace() error: Text restorer function for "
-					.. nj_child.p_ft
-					.. " failed ..."
-					.. tostring(restored_text)
-				if cfg.debug then
-					vim.notify(err, vim.log.levels.ERROR)
-				end
-				return false, err
-			else
-				rep_lines = restored_text
+			local err = "ninjection.replace() error: Text restorer function for "
+				.. nj_child.p_ft
+				.. " failed ..."
+				.. tostring(restored_text)
+			if cfg.debug then
+				vim.notify(err, vim.log.levels.ERROR)
 			end
+			return false, err
+		else
+			rep_lines = restored_text
 		end
 	end
 

--- a/lua/ninjection/types.lua
+++ b/lua/ninjection/types.lua
@@ -71,10 +71,6 @@
 ---@field inj_text_restorers? table<string, NJTextRestorer> - Contains
 --- per-language functions to restore modified text
 ---
----@field inj_lang_tweaks? table<string, NJLangTweak> - Contains
---- language functions to workaround limitations in Treesitter queries and post-process
---- injected content selections.
----
 ---@field lsp_map? table<string, string> - Maps the injected language filetype
 --- comment to an LSP configuration name for that filetype.
 
@@ -100,13 +96,6 @@
 ---
 ---@field inj_lang string Language tag extracted from inj_lang capture
 ---@field node TSNode Node associated with the injected code
-
----@tag NJLangTweak
----@class NJLangTweak
----@brief Language specific adjustments for tweaking parsing and buffers.
----
----@field parse_range_offset NJRange
----@field buffer_cursor_offset NJRange
 
 ---@tag NJNodeTable
 ---@class NJNodeTable


### PR DESCRIPTION
  Design + cleanup pass ahead of generalising injected-language editing beyond bash/sh. No Python implementation yet —
  this lands the bug fix, cleanup, and the decisions that shape it.

  - fix: restorer corruption at debug=false — the inj_text_restorers call that re-adds the outer ''…''; block delimiters
  was gated behind cfg.debug, which is only a verbosity switch. The transform is load-bearing (the write-back range covers
  the whole injected node), so debug=false silently dropped the delimiters and corrupted the parent buffer on every
  round-trip. Verified across the bash/lua/nix specs (now green at both debug settings).
  - refactor: remove dead config — inj_lang_tweaks / parse_range_offset / buffer_cursor_offset (+ NJLangTweak) were
  defined but consumed nowhere; they scaffolded an abandoned range-exclusion model we explicitly chose against, and
  described a non-existent behavior that had misled analysis of the restorer.
  - build: add ruff to the devShell (Python LSP/formatter).
  - docs: ADR-0005 — interpolation handling is injected-language-keyed (shell rewrites ${x}; non-shell leaves
  interpolations verbatim, else string-position interps corrupt). Real-value resolution deferred but not foreclosed (will
  need extmark tracking). CONTEXT/TODO reconciled.
