### PR TITLE
fix: pin string root_dir before starting injected LSP

### DIFF
--- a/lua/ninjection/init.lua
+++ b/lua/ninjection/init.lua
@@ -246,7 +246,7 @@ function ninjection.edit()
 	})
 
 	---@type NJLspStatus?, string?
-	local c_lsp, lsp_err = lsp.start_lsp(injection.pair.inj_lang, nj_child.c_bufnr)
+	local c_lsp, lsp_err = lsp.start_lsp(injection.pair.inj_lang, nj_child.c_bufnr, nj_child.c_root_dir)
 	if not c_lsp or c_lsp.status == lsp.LspStatusMsg then
 		---@type string
 		local err = "ninjection.edit() warning: starting LSP failed ... " .. tostring(lsp_err)
@@ -556,7 +556,7 @@ function ninjection.format()
 	nj_parent:add_child(nj_child.c_bufnr)
 
 	---@type NJLspStatus?, string?
-	local lsp_status, lsp_err = lsp.start_lsp(injection.pair.inj_lang, nj_child.c_bufnr)
+	local lsp_status, lsp_err = lsp.start_lsp(injection.pair.inj_lang, nj_child.c_bufnr, nj_child.c_root_dir)
 	if not lsp_status then
 		-- start_lsp should always return a status
 		return false, tostring(lsp_err)

--- a/lua/ninjection/lsp.lua
+++ b/lua/ninjection/lsp.lua
@@ -87,9 +87,12 @@ M.NJLspStatus = NJLspStatus
 --- Parameters ~
 ---@param lang string - The filetype of the injected language (e.g., "lua", "python").
 ---@param bufnr integer - The bufnr handle to attach the LSP to.
+---@param root_dir string? - Concrete project root for the child. Used to override a
+--- dynamic (function-form) `root_dir` in the resolved config, which `vim.lsp.start()`
+--- does not resolve. Falls back to the cwd when omitted.
 ---
 ---@return NJLspStatus? result, string? err - The LSP status.
-function M.start_lsp(lang, bufnr)
+function M.start_lsp(lang, bufnr, root_dir)
 	-- The injected language must be mapped to an LSP
 	---@type string?
 	local lang_lsp = cfg.lsp_map[lang]
@@ -135,8 +138,25 @@ function M.start_lsp(lang, bufnr)
 		return NJLspStatus.new(LspStatusMsg.NO_EXEC, nil), err
 	end
 
+	-- `vim.lsp.config[name]` is a `vim.lsp.Config`, which may carry a dynamic
+	-- (function-form) `root_dir` resolved only by the `vim.lsp.enable` autostart
+	-- framework. `vim.lsp.start()` does NOT resolve it; it would hand the function
+	-- straight to the client, leaving `client.root_dir` a function. That both hangs
+	-- the synchronous start and crashes downstream plugins (e.g. lazydev) that call
+	-- `vim.fs.normalize(client.root_dir)`. Our child is a synthetic scratch buffer
+	-- with no real file, so marker-based resolution is meaningless anyway; pin a
+	-- concrete string root instead. Deep-copy first so the shared global config is
+	-- left untouched.
+	---@type vim.lsp.ClientConfig
+	local client_cfg = vim.deepcopy(lsp_cfg)
+	if type(root_dir) == "string" and root_dir ~= "" then
+		client_cfg.root_dir = root_dir
+	elseif type(client_cfg.root_dir) ~= "string" then
+		client_cfg.root_dir = vim.fn.getcwd()
+	end
+
 	---@type integer?
-	local client_id = vim.lsp.start(lsp_cfg, { bufnr = bufnr })
+	local client_id = vim.lsp.start(client_cfg, { bufnr = bufnr })
 	if not client_id then
 		---@type string
 		local err = "ninjection.lsp.start_lsp() warning: The LSP, "

--- a/tests/ft/nix/lua/lua_in_nix_lsp_root_dir_spec.lua
+++ b/tests/ft/nix/lua/lua_in_nix_lsp_root_dir_spec.lua
@@ -1,0 +1,69 @@
+package.path = vim.fn.getcwd() .. "/tests/e2e/?.lua;" .. package.path
+
+local lsp = require("ninjection.lsp")
+
+-- Regression for the function-form `root_dir` crash.
+--
+-- nvim-lspconfig / nixvim configure `vim.lsp.config.lua_ls.root_dir` as a
+-- *function* (the `fun(bufnr, on_dir)` form). `vim.lsp.start()` does not resolve
+-- that form (only the `vim.lsp.enable` autostart path does), so handing the
+-- config through verbatim left `client.root_dir` a function. That hung the
+-- synchronous start and crashed downstream plugins that call
+-- `vim.fs.normalize(client.root_dir)` -- e.g. lazydev:
+--   "vim/fs.lua: path: expected string, got function".
+-- start_lsp() must pin a concrete string root before starting the client.
+describe("ninjection.lsp.start_lsp dynamic root_dir #e2e #lua-nix #lsp", function()
+	local saved_lua_ls
+	local started_client_id
+
+	before_each(function()
+		saved_lua_ls = vim.lsp.config["lua_ls"]
+	end)
+
+	after_each(function()
+		if started_client_id then
+			local client = vim.lsp.get_client_by_id(started_client_id)
+			if client then
+				pcall(function()
+					client:stop(true)
+				end)
+			end
+			started_client_id = nil
+		end
+		vim.lsp.config["lua_ls"] = saved_lua_ls
+	end)
+
+	it("pins a string root_dir when the config provides a function", function()
+		local dynamic_cfg = vim.deepcopy(vim.lsp.config["lua_ls"] or {})
+		dynamic_cfg.root_dir = function(_, on_dir)
+			on_dir(vim.fn.getcwd())
+		end
+		vim.lsp.config["lua_ls"] = dynamic_cfg
+
+		local child_bufnr = vim.api.nvim_create_buf(true, true)
+		vim.api.nvim_buf_set_lines(child_bufnr, 0, -1, false, { "local x = 1" })
+		vim.api.nvim_set_option_value("filetype", "lua", { buf = child_bufnr })
+
+		local status, err = lsp.start_lsp("lua", child_bufnr, vim.fn.getcwd())
+
+		-- Skip gracefully when the language server binary is unavailable.
+		if status and status.status == lsp.LspStatusMsg.NO_EXEC then
+			print("[INFO] lua-language-server not on PATH; skipping root_dir assertion")
+			return
+		end
+
+		assert.are.equal(lsp.LspStatusMsg.STARTED, status and status.status, tostring(err))
+		assert.is_truthy(status.client_id)
+		started_client_id = status.client_id
+
+		local client = vim.lsp.get_client_by_id(status.client_id)
+		assert.is_truthy(client)
+		-- The crash precondition: client.root_dir must be a usable string.
+		assert.are.equal("string", type(client.root_dir))
+		local normalize_ok = pcall(vim.fs.normalize, client.root_dir)
+		assert.is_true(normalize_ok, "vim.fs.normalize must accept client.root_dir")
+
+		-- The shared global config must not have been mutated by start_lsp.
+		assert.are.equal("function", type(vim.lsp.config["lua_ls"].root_dir))
+	end)
+end)


### PR DESCRIPTION
start_lsp() handed the resolved `vim.lsp.config[name]` entry straight to `vim.lsp.start()`. That entry is a `vim.lsp.Config`, whose `root_dir` may be a function (the `fun(bufnr, on_dir)` form used by nvim-lspconfig / nixvim). `vim.lsp.start()` does not resolve the function form -- only the `vim.lsp.enable` autostart path does -- so the started client kept `client.root_dir` as a function. Downstream `LspAttach` consumers then crashed on it, e.g. lazydev calling `vim.fs.normalize(client.root_dir)`:

  vim/fs.lua: path: expected string, got function

The function form also hangs a synchronous start. ninjection already computes a concrete string project root (`c_root_dir`); pass it through and override the config's `root_dir` with it (on a deep copy so the shared global config is left untouched). The child is a synthetic scratch buffer with no backing file, so marker-based resolution would be meaningless anyway.

Adds a regression test that configures a function-form `root_dir` -- the real trigger -- and asserts the started client's `root_dir` is a normalize-able string. The dev env's `lua_ls.root_dir` is nil, which is why the existing suite never exercised this path.